### PR TITLE
noscript.inc.html.ep: Fix typo

### DIFF
--- a/upstream/templates/noscript.inc.html.ep
+++ b/upstream/templates/noscript.inc.html.ep
@@ -6,7 +6,7 @@
       </div>
       <div class="col-sm-9">
         <h2>JavaScript is disabled!</h2>
-        <p>We have carefully crafted an innovative experience for the Korora community and hope you find us trustworthy enough to enable JavaScript try it out in it's full glory. This entire website, including all of our JavaScript, <a href="https://github.com/kororaproject/kp-canvas">is open source</a>.</p>
+        <p>We have carefully crafted an innovative experience for the Korora community and hope you find us trustworthy enough to enable JavaScript try it out in its full glory. This entire website, including all of our JavaScript, <a href="https://github.com/kororaproject/kp-canvas">is open source</a>.</p>
         <p>Thank you for your consideration.</p>
       </div>
     </div>


### PR DESCRIPTION
Without Javascript, the first sentence on the website contains a typo. Not a very good first impression!

Fix the typo.
