### PR TITLE
cli bash completion 

### DIFF
--- a/upstream/client/cnvs
+++ b/upstream/client/cnvs
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+# PYTHON_ARGCOMPLETE_OK
 
 import dnf
 import logging

--- a/upstream/client/lib/canvas/cli/commands/__init__.py
+++ b/upstream/client/lib/canvas/cli/commands/__init__.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import argcomplete
 import argparse
 import logging
 import os
@@ -259,6 +260,7 @@ def parseCommandLine(config):
 
   # parse known commands printing general usage on any error
   try:
+    argcomplete.autocomplete(parser)
     args, args_extra = parser.parse_known_args()
 
   except:


### PR DESCRIPTION
Use argcomplete for automatic bash completion of the canvas cli tool.

This requires python3-argcomplete which is available on [koji](http://koji.fedoraproject.org/koji/buildinfo?buildID=640664).
