### PR TITLE
Improve search engine listing using http://schema.org/CreativeWork

### DIFF
--- a/templates/banner.inc.html.ep
+++ b/templates/banner.inc.html.ep
@@ -3,12 +3,12 @@
   <div class="container">
     <div class="row">
       <div class="col-xs-12 col-sm-3 center vcenter">
-        <h1><b>Korora</b> 23</h1>
+        <h1><b itemprop="name">Korora</b> 23</h1>
         <h2>New. Improved. Solid.</h2>
       </div><!--
    --><div class="col-xs-12 col-sm-6 vcenter">
         <div class="laptop">
-          <img id="img-banner" class="img-responsive" src="/img/generic-laptop-korora-gnome-desktop.png" alt="Korora on laptop">
+          <img id="img-banner" class="img-responsive" src="/img/generic-laptop-korora-gnome-desktop.png" alt="Korora on laptop" itemprop="image">
         </div>
       </div><!--
  --><div class="col-xs-12 col-sm-3 center vcenter">

--- a/templates/index.html.ep
+++ b/templates/index.html.ep
@@ -4,7 +4,7 @@
   %= include 'header.inc', title => 'Korora Project'
   <link href="/css/layerslider.css" rel="stylesheet" media="screen">
 </head>
-<body>
+<body itemscope itemtype="http://schema.org/CreativeWork">
   %= include 'noscript.inc'
 
   <div class="page-container">
@@ -16,6 +16,13 @@
       <!-- CONTENT -->
 
       <div class="container">
+        <meta itemprop="url" content="https://kororaproject.org/download">
+        <span itemprop="author" itemscope itemtype="http://schema.org/Organization">
+          <meta itemprop="name" content="Korora Project">
+          <meta itemprop="url" content="https://kororaproject.org/about/team">
+        </span>
+        <meta itemprop="license" content="https://kororaproject.org/about/whats-inside">
+        <meta itemprop="keywords" content="korora, linux, easy, expert, fedora, remix, innovation, community, security, choice, freedom">
         <div class="row">
           <div class="col-sm-12">
             <h1 class="text-center">Latest News</h1>
@@ -58,10 +65,11 @@
                 <div class="quote">
                   <p>Using a special blend of aesthetics and functionality, Korora aims to make Linux easier for new users without compromising its power and flexibility for experts.</p>
                   <p>We provide a complete and easy to use computing system that "Just&nbsp;Works" &ndash; right out of the box.</p>
+                  <meta itemprop="description" content='Using a special blend of aesthetics and functionality, Korora aims to make Linux easier for new users without compromising its power and flexibility for experts. We provide a complete and easy to use computing system that "Just&nbsp;Works" &ndash; right out of the box.' />
                 </div>
               </div><!--
            --><div class="col-sm-6 vcenter">
-                <img class="img-responsive" src="/img/generic-laptop-korora-gnome-desktop-apps.png" alt="Korora GNOME desktop running Firefox and Nautilus.">
+                <img class="img-responsive" src="/img/generic-laptop-korora-gnome-desktop-apps.png" alt="Korora GNOME desktop running Firefox and Nautilus." itemprop="image">
               </div>
             </div>
           </div>


### PR DESCRIPTION
added: CreativeWork schema (http://schema.org/CreativeWork) to index page template to help with search engine results

The hope is that these changes will tidy up the search engine listing when people search for Korora.

I looked at all the available schema types and CreativeWork seemed to fit the best. Product requires a price and as such has a strong feeling of selling something. SoftwareApplication is aimed more at apps and doesn't really fit an OS.

I tested the schema additions using: https://developers.google.com/structured-data/testing-tool/
![korora-website-schema-test](https://cloud.githubusercontent.com/assets/5102396/14407458/df7496cc-ff0c-11e5-9cfc-5da9abdbf3d7.png)

I didn't test if the additions break the site.
