### PR TITLE
canvas.css

### DIFF
--- a/public/css/canvas.css
+++ b/public/css/canvas.css
@@ -1010,6 +1010,7 @@ blockquote p {
 .page-container {
   min-height: 100%;
   margin-bottom: 256px; /* auto-calculated */
+  -webkit-margin-bottom-collapse: discard; /* Fixes Footer Cut of in mobile view - Dazzy */
   padding-bottom: 64px; /* match top padding of page-content */
 
   background-color: #fff;


### PR DESCRIPTION
Fix for footer not showing properly on mobile

.page-container {
    min-height: 100%;
    margin-bottom: 256px;
    -webkit-margin-bottom-collapse: discard; /* Fixes Footer Cut of in mobile view - Dazzy */
    padding-bottom: 64px;
    background-color: #fff;
    box-shadow: 0px 2px 8px rgba(32, 32, 32, 0.8);
}